### PR TITLE
Improve AI landing page design

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,26 +4,68 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI in Mobile Testing</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="hero">
-        <h1 class="title">AI in Mobile Testing</h1>
-        <p class="subtitle">Exploring the role of artificial intelligence in modern native app QA.</p>
-        <div class="phone">
-            <img src="phone.png" alt="Mobile Phone" />
+    <header class="topbar">
+        <div class="lang-switch">
+            <button data-lang="en" class="active">EN</button>
+            <button data-lang="ua">UA</button>
         </div>
-    </div>
-    <section class="content">
-        <h2>Enhancing QA with AI</h2>
-        <p>
-            Artificial intelligence helps automate repetitive tasks, identify edge cases, and predict user behavior.
-            By integrating AI, testers can focus on complex scenarios while machines handle the bulk of regression testing.
-        </p>
-        <p>
-            In mobile native applications, AI-driven testing frameworks can simulate diverse network conditions, hardware configurations,
-            and user interactions to reveal issues that might otherwise be missed.
-        </p>
+        <label class="switch">
+            <input type="checkbox" id="modeToggle">
+            <span class="slider"></span>
+        </label>
+    </header>
+
+    <section class="hero hidden">
+        <h1 class="title" data-en="AI in Mobile Testing" data-ua="ШІ у мобільному тестуванні">AI in Mobile Testing</h1>
+        <p class="subtitle" data-en="Exploring the role of artificial intelligence in modern native app QA." data-ua="Вивчаємо роль штучного інтелекту в тестуванні мобільних застосунків.">Exploring the role of artificial intelligence in modern native app QA.</p>
+        <div class="phone">
+            <div class="phone-body">
+                <div class="screen">
+                    <div class="scan"></div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="ai-block hidden">
+        <h2 data-en="Real-time AI Analysis" data-ua="Аналіз ШІ в реальному часі">Real-time AI Analysis</h2>
+        <p data-en="AI analyzes UI, UX and bug reports in real time." data-ua="ШІ аналізує UI, UX і баг-репорти в реальному часі.">AI analyzes UI, UX and bug reports in real time.</p>
+    </section>
+
+    <section class="timeline hidden">
+        <h2 data-en="AI-Powered QA Process" data-ua="AI-процес QA">AI-Powered QA Process</h2>
+        <ol class="timeline-list">
+            <li><span class="step" data-en="Collect data" data-ua="Збір даних">Collect data</span></li>
+            <li><span class="step" data-en="Train models" data-ua="Навчання моделей">Train models</span></li>
+            <li><span class="step" data-en="Execute tests" data-ua="Виконання тестів">Execute tests</span></li>
+            <li><span class="step" data-en="Report insights" data-ua="Звіт про інсайти">Report insights</span></li>
+        </ol>
+    </section>
+
+    <section class="faq hidden">
+        <h2 data-en="AI FAQ" data-ua="Часті питання про ШІ">AI FAQ</h2>
+        <div class="faq-item">
+            <button class="question" data-en="What is AI-based testing?" data-ua="Що таке тестування на основі ШІ?">What is AI-based testing?</button>
+            <div class="answer" data-en="It uses machine learning to enhance and automate QA." data-ua="Це використання машинного навчання для покращення та автоматизації QA.">It uses machine learning to enhance and automate QA.</div>
+        </div>
+        <div class="faq-item">
+            <button class="question" data-en="Does it replace testers?" data-ua="Чи заміняє це тестувальників?">Does it replace testers?</button>
+            <div class="answer" data-en="No, AI assists testers by handling routine checks." data-ua="Ні, ШІ допомагає тестувальникам, виконуючи рутинні перевірки.">No, AI assists testers by handling routine checks.</div>
+        </div>
+    </section>
+
+    <section class="contact hidden">
+        <h2 data-en="Request a Demo" data-ua="Запросити демо">Request a Demo</h2>
+        <form id="contactForm">
+            <input type="text" id="name" placeholder="Name">
+            <input type="email" id="email" placeholder="Email">
+            <textarea id="message" placeholder="Message"></textarea>
+            <button type="submit">Send</button>
+        </form>
     </section>
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,51 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const title = document.querySelector('.title');
-    title.style.opacity = '0';
-    setTimeout(() => {
-        title.style.transition = 'opacity 1.5s';
-        title.style.opacity = '1';
-    }, 500);
+    // Dark mode toggle
+    const modeToggle = document.getElementById('modeToggle');
+    modeToggle.addEventListener('change', () => {
+        document.body.classList.toggle('dark', modeToggle.checked);
+    });
+
+    // Language switch
+    document.querySelectorAll('.lang-switch button').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.lang-switch button').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+            const lang = btn.dataset.lang;
+            document.querySelectorAll('[data-en]').forEach(el => {
+                el.textContent = el.dataset[lang];
+            });
+        });
+    });
+
+    // Intersection observer for animations
+    const observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('show');
+                observer.unobserve(entry.target);
+            }
+        });
+    }, { threshold: 0.2 });
+    document.querySelectorAll('.hidden').forEach(el => observer.observe(el));
+
+    // FAQ toggle
+    document.querySelectorAll('.faq-item .question').forEach(q => {
+        q.addEventListener('click', () => {
+            q.parentElement.classList.toggle('open');
+        });
+    });
+
+    // Contact form validation
+    document.getElementById('contactForm').addEventListener('submit', e => {
+        e.preventDefault();
+        const name = document.getElementById('name').value.trim();
+        const email = document.getElementById('email').value.trim();
+        const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!name || !emailPattern.test(email)) {
+            alert('Please enter your name and a valid email.');
+            return;
+        }
+        alert('Thank you! We will reach out soon.');
+        e.target.reset();
+    });
 });

--- a/style.css
+++ b/style.css
@@ -1,59 +1,260 @@
+:root {
+    --accent: #7b5cff;
+    --bg: #f4f4f4;
+    --text: #333;
+    --surface: #ffffff;
+    --bg-dark: #121212;
+    --text-dark: #eaeaea;
+    --surface-dark: #1f1f1f;
+}
+
 body {
     margin: 0;
-    font-family: Arial, Helvetica, sans-serif;
-    background: #f4f4f4;
+    font-family: 'Poppins', Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
     overflow-x: hidden;
+    transition: background 0.3s, color 0.3s;
+}
+
+body.dark {
+    background: var(--bg-dark);
+    color: var(--text-dark);
+}
+
+.topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5em 1em;
+}
+
+.lang-switch button {
+    background: none;
+    border: none;
+    color: inherit;
+    font-size: 0.9em;
+    margin-right: 0.5em;
+    cursor: pointer;
+    opacity: 0.7;
+}
+
+.lang-switch button.active {
+    opacity: 1;
+    color: var(--accent);
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 40px;
+    height: 20px;
+}
+
+.switch input { display: none; }
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: #ccc;
+    border-radius: 34px;
+    transition: background 0.2s;
+}
+
+.slider:before {
+    position: absolute;
+    content: '';
+    height: 16px;
+    width: 16px;
+    left: 2px;
+    bottom: 2px;
+    background: white;
+    border-radius: 50%;
+    transition: transform 0.2s;
+}
+
+.switch input:checked + .slider {
+    background: var(--accent);
+}
+
+.switch input:checked + .slider:before {
+    transform: translateX(20px);
 }
 
 .hero {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100vh;
-    background: linear-gradient(120deg, #4e54c8, #8f94fb);
+    padding: 4em 1em;
+    text-align: center;
+    background: linear-gradient(120deg, var(--accent), #8f94fb);
     color: white;
-    text-align: center;
-    animation: slideIn 1.5s ease-out forwards;
 }
 
-@keyframes slideIn {
-    from { transform: translateY(-50px); opacity: 0; }
-    to { transform: translateY(0); opacity: 1; }
+.phone {
+    margin-top: 2em;
 }
 
-.title {
-    font-size: 3em;
-    margin: 0.2em 0;
-}
-
-.subtitle {
-    font-size: 1.2em;
-    margin: 0 0 2em 0;
-}
-
-.phone img {
+.phone-body {
     width: 200px;
-    animation: float 3s ease-in-out infinite;
+    height: 400px;
+    border: 8px solid #333;
+    border-radius: 30px;
+    margin: 0 auto;
+    background: #000;
+    position: relative;
+    overflow: hidden;
 }
 
-@keyframes float {
-    0%, 100% { transform: translateY(0); }
-    50% { transform: translateY(-20px); }
+.phone-body .screen {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    right: 10px;
+    bottom: 10px;
+    background: #fff;
+    border-radius: 20px;
+    overflow: hidden;
 }
 
-.content {
-    padding: 2em;
-    background: white;
+.screen .scan {
+    position: absolute;
+    width: 100%;
+    height: 4px;
+    background: var(--accent);
+    animation: scan 2s linear infinite;
 }
 
-.content h2 {
+@keyframes scan {
+    0% { top: 0; }
+    100% { top: calc(100% - 4px); }
+}
+
+.ai-block {
+    padding: 3em 1em;
     text-align: center;
-    color: #4e54c8;
+    background: linear-gradient(120deg, #8f94fb, var(--accent));
+    color: white;
 }
 
-.content p {
+.timeline {
+    padding: 3em 1em;
+}
+
+.timeline-list {
+    list-style: none;
+    max-width: 600px;
+    margin: 2em auto;
+    padding: 0;
+}
+
+.timeline-list li {
+    position: relative;
+    padding-left: 2em;
+    margin-bottom: 2em;
+}
+
+.timeline-list li:before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.35em;
+    width: 10px;
+    height: 10px;
+    background: var(--accent);
+    border-radius: 50%;
+}
+
+.faq {
+    padding: 3em 1em;
+    background: var(--surface);
+}
+
+body.dark .faq {
+    background: var(--surface-dark);
+}
+
+.faq-item {
     max-width: 600px;
     margin: 1em auto;
-    line-height: 1.6;
+    border-bottom: 1px solid #ddd;
+}
+
+body.dark .faq-item {
+    border-color: #444;
+}
+
+.faq-item .question {
+    width: 100%;
+    background: none;
+    border: none;
+    text-align: left;
+    padding: 1em;
+    font-size: 1em;
+    cursor: pointer;
+    color: inherit;
+}
+
+.faq-item .answer {
+    display: none;
+    padding: 0 1em 1em;
+}
+
+.faq-item.open .answer {
+    display: block;
+}
+
+.contact {
+    padding: 3em 1em;
+}
+
+form {
+    max-width: 600px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+}
+
+form input,
+form textarea {
+    margin: 0.5em 0;
+    padding: 0.8em;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 1em;
+}
+
+body.dark form input,
+body.dark form textarea {
+    background: #333;
+    border-color: #555;
+    color: var(--text-dark);
+}
+
+form button {
+    padding: 0.8em;
+    border: none;
+    background: var(--accent);
+    color: white;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.hidden {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s, transform 0.6s;
+}
+
+.show {
+    opacity: 1;
+    transform: none;
+}
+
+@media(max-width: 600px) {
+    .phone-body {
+        width: 150px;
+        height: 300px;
+    }
 }


### PR DESCRIPTION
## Summary
- revamp landing page layout with hero, AI analysis, timeline, FAQ and contact sections
- add dark/light mode toggle and UA/EN language switcher
- create phone mock animation and scrolling reveal effects via Intersection Observer
- style page with new gradients and Poppins font
- add JS for language switching, dark mode, FAQ toggling and form validation

## Testing
- `python3 main.py`


------
https://chatgpt.com/codex/tasks/task_e_684360e5406c8330a461dc347fffc15e